### PR TITLE
Fix case sensitivity issue

### DIFF
--- a/src/CustomItemService.js
+++ b/src/CustomItemService.js
@@ -49,7 +49,7 @@ class CustomItemService {
         this.instanceManager = instanceManager;
     }
     postDBLoad() {
-        const configPath = path.join(__dirname, "../db/Items");
+        const configPath = path.join(__dirname, "../db/items");
         const configFiles = fs
             .readdirSync(configPath)
             .filter((file) => !file.includes("BaseItemReplacement"));

--- a/src/CustomItemService.ts
+++ b/src/CustomItemService.ts
@@ -26,7 +26,7 @@ export class CustomItemService {
     }
 
     public postDBLoad(): void {
-        const configPath = path.join(__dirname, "../db/Items");
+        const configPath = path.join(__dirname, "../db/items");
         const configFiles = fs
             .readdirSync(configPath)
             .filter((file) => !file.includes("BaseItemReplacement"));


### PR DESCRIPTION
Hello,

You create your item path as db/items but then refer to it as db/Items, this probably slipped through since windows doesn't care about case, but linux does. I've changed the case to properly reflect the actual directory name so it works on both Windows and Linux (tested)